### PR TITLE
Update gems to be compatible with Ruby 2.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,19 +2,20 @@ source "https://rubygems.org"
 ruby '2.3.1'
 
 group :development do
-  gem 'rake', '~> 10.0'
-  gem 'jekyll', '~> 2.0'
-  gem 'octopress-hooks', '~> 2.2'
-  gem 'octopress-date-format', '~> 2.0'
-  gem 'jekyll-sitemap'
-  gem 'rdiscount', '~> 2.0'
+  gem 'rake', '~> 10.5'
+  gem 'jekyll', '~> 2.5.3'
+  gem 'octopress-hooks', '~> 2.6.1'
+  gem 'octopress-date-format', '~> 2.0.2'
+  gem 'jekyll-sitemap', '~> 0.11.0'
+  gem 'rdiscount', '~> 2.2.0.1'
   gem 'RedCloth', '~> 4.2.9'
-  gem 'haml', '~> 4.0'
-  gem 'compass', '~> 0.12.2'
+  gem 'haml', '~> 4.0.7'
+  gem 'compass', '~> 0.12.7'
   gem 'sass-globbing', '~> 1.0.0'
   gem 'rubypants', '~> 0.2.0'
-  gem 'rb-fsevent', '~> 0.9'
+  gem 'rb-fsevent', '~> 0.9.7'
   gem 'stringex', '~> 1.4.0'
 end
 
-gem 'sinatra', '~> 1.4.2'
+# Use Sinatra as the web server
+gem 'sinatra', '~> 1.4.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     RedCloth (4.2.9)
     addressable (2.4.0)
     blankslate (2.1.2.4)
-    chunky_png (1.3.6)
+    chunky_png (1.3.7)
     classifier-reborn (2.0.4)
       fast-stemmer (~> 1.0)
     coffee-script (2.4.1)
@@ -102,18 +102,18 @@ PLATFORMS
 
 DEPENDENCIES
   RedCloth (~> 4.2.9)
-  compass (~> 0.12.2)
-  haml (~> 4.0)
-  jekyll (~> 2.0)
-  jekyll-sitemap
-  octopress-date-format (~> 2.0)
-  octopress-hooks (~> 2.2)
-  rake (~> 10.0)
-  rb-fsevent (~> 0.9)
-  rdiscount (~> 2.0)
+  compass (~> 0.12.7)
+  haml (~> 4.0.7)
+  jekyll (~> 2.5.3)
+  jekyll-sitemap (~> 0.11.0)
+  octopress-date-format (~> 2.0.2)
+  octopress-hooks (~> 2.6.1)
+  rake (~> 10.5)
+  rb-fsevent (~> 0.9.7)
+  rdiscount (~> 2.2.0.1)
   rubypants (~> 0.2.0)
   sass-globbing (~> 1.0.0)
-  sinatra (~> 1.4.2)
+  sinatra (~> 1.4.7)
   stringex (~> 1.4.0)
 
 RUBY VERSION


### PR DESCRIPTION
Fixes #2.

Got a report from @Nbarnes1 that `jekyll serve` didn't work with Ruby 2.3.1. So, this updates the Gemfile to make sure that it will work with Ruby 2.3.1.

However, weird thing to note, there were no major version changes necessary to get this to work so some gem wasn't following the correct versioning strategy. :/
## Testing

@Nbarnes1, pull the repo, checkout the branch, and make sure everything works. Let me know if you run into any issues and/or it was successful!
